### PR TITLE
Add option to use doc/make_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ All of the following inputs are optional.
 - use-latex:
   - if `true`, then install and use latex
   - default: `false`
+- use-makedoc-shell-script:
+  - if true, call `doc/make_doc` instead of `makedoc.g`
+  - default: `false`
 
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Compile package documentation'
+name: 'Compile GAP package documentation'
 description: 'Compile documentation with or without latex'
 inputs:
   use-latex:
@@ -8,21 +8,31 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - run: |
-          if [ ${{inputs.use-latex}} = 'true' ]
-          then
-            packages=(
-              texlive-latex-base
-              texlive-latex-recommended
-              texlive-latex-extra
-              texlive-extra-utils
-              texlive-fonts-recommended texlive-fonts-extra
-            )
-            sudo apt-get install "${packages[@]}"
-          fi
-        shell: bash
-      - name: "Compile documentation"
-        run:  $HOME/gap/bin/gap.sh -l "$PWD/gaproot;" --quitonbreak makedoc.g -c "QUIT;"
-        shell: bash
-        env:
-          SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF
+    - name: "Install TeX Live"
+      shell: bash
+      run: |
+        if [ ${{ inputs.use-latex }} == 'true' ]; then
+          packages=(
+            texlive-latex-base
+            texlive-latex-recommended
+            texlive-latex-extra
+            texlive-extra-utils
+            texlive-fonts-recommended texlive-fonts-extra
+          )
+          sudo apt-get install "${packages[@]}"
+        fi
+
+    - name: "Compile documentation"
+      shell: bash
+      run: |
+        if [ -f "makedoc.g" ]; then
+          $HOME/gap/bin/gap.sh -l "$PWD/gaproot;" --quitonbreak makedoc.g -c "QUIT;"
+        elif [ -f "doc/make_doc" ]; then
+           cd doc
+           ./make_doc
+        else
+          echo "no makedoc.g file or doc/make_doc script found!"
+          exit 1
+        fi
+      env:
+        SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF


### PR DESCRIPTION
Fixes #3.

This is obviously based on @ssiccha's PR #4, but that one wouldn't work for syntax reasons that I couldn't quite work out.

Basically, I don't think we are allow to do things like:
```
steps:
  - if: 
```
I don't know why these `if` statements aren't allowed, since they're allowed in the workflow files that we use in (say) GAP's `.github/workflows/CI.yml`. That probably explains why the LaTeX step already had its `if` inside the `bash` code, rather than in the YAML.

Anyway, this lacks the "Setup tmate session on failure" of PR #4, but perhaps that can be added later if we work out how to do it.

And it works fine, as shown https://github.com/wilfwilson/sonata/pull/2